### PR TITLE
Emulator Backend API and Generic Test

### DIFF
--- a/drivers/sensor/akm09918c/akm09918c.h
+++ b/drivers/sensor/akm09918c/akm09918c.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_AKM09918C_AKM09918C_H_
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 
 #include "akm09918c_reg.h"
@@ -15,7 +16,13 @@
 #define AKM09918C_MEASURE_TIME_US 9000
 
 /* Conversion values */
-#define AKM09918C_MICRO_GAUSS_PER_BIT INT64_C(500)
+#define AKM09918C_MICRO_GAUSS_PER_BIT INT64_C(1500)
+
+/* Maximum and minimum magnetometer values in microgauss. +/-32752 is the maximum range of the
+ * data registers (slightly less than the range of int16). This works out to +/- 49,128,000 uGs
+ */
+#define AKM09918C_MAGN_MAX_MICRO_GAUSS (32752 * AKM09918C_MICRO_GAUSS_PER_BIT)
+#define AKM09918C_MAGN_MIN_MICRO_GAUSS (-32752 * AKM09918C_MICRO_GAUSS_PER_BIT)
 
 struct akm09918c_data {
 	int16_t x_sample;

--- a/drivers/sensor/akm09918c/akm09918c_emul.c
+++ b/drivers/sensor/akm09918c/akm09918c_emul.c
@@ -7,10 +7,13 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/emul_sensor.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i2c_emul.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 
+#include "akm09918c.h"
 #include "akm09918c_emul.h"
 #include "akm09918c_reg.h"
 
@@ -130,14 +133,94 @@ static int akm09918c_emul_init(const struct emul *target, const struct device *p
 	return 0;
 }
 
+static int akm09918c_emul_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+					      q31_t value, uint8_t shift)
+{
+	if (!target || !target->data) {
+		return -EINVAL;
+	}
+
+	struct akm09918c_emul_data *data = target->data;
+	uint8_t reg;
+
+	switch (ch) {
+	case SENSOR_CHAN_MAGN_X:
+		reg = AKM09918C_REG_HXL;
+		break;
+	case SENSOR_CHAN_MAGN_Y:
+		reg = AKM09918C_REG_HYL;
+		break;
+	case SENSOR_CHAN_MAGN_Z:
+		reg = AKM09918C_REG_HZL;
+		break;
+	/* This function only supports setting single channels, so skip MAGN_XYZ */
+	default:
+		return -ENOTSUP;
+	}
+
+	/* Set the ST1 register to show we have data */
+	data->reg[AKM09918C_REG_ST1] |= AKM09918C_ST1_DRDY;
+
+	/* Convert fixed-point Gauss values into microgauss and then into its bit representation */
+	int32_t microgauss = (shift < 0 ? ((int64_t)value >> -shift) : ((int64_t)value << shift)) *
+			     1000000 / ((int64_t)INT32_MAX + 1);
+
+	LOG_WRN("q=%d, shift=%d, microgauss=%d, ch=%d", value, shift, microgauss, ch);
+
+	int16_t reg_val =
+		CLAMP(microgauss, AKM09918C_MAGN_MIN_MICRO_GAUSS, AKM09918C_MAGN_MAX_MICRO_GAUSS) /
+		AKM09918C_MICRO_GAUSS_PER_BIT;
+
+	/* Insert reading into registers */
+	data->reg[reg] = reg_val & 0xFF;
+	data->reg[reg + 1] = (reg_val >> 8) & 0xFF;
+
+	LOG_WRN("Reg: %02x, Val: %04x", reg, reg_val);
+
+	return 0;
+}
+
+static int akm09918c_emul_backend_get_sample_range(const struct emul *target,
+						   enum sensor_channel ch, q31_t *lower,
+						   q31_t *upper, q31_t *epsilon, int8_t *shift)
+{
+	ARG_UNUSED(target);
+
+	if (!lower || !upper || !epsilon || !shift) {
+		return -EINVAL;
+	}
+
+	switch (ch) {
+	case SENSOR_CHAN_MAGN_X:
+	case SENSOR_CHAN_MAGN_Y:
+	case SENSOR_CHAN_MAGN_Z:
+		/* +/- 49.12 Gs is the measurement range. 0.0015 Gs is the  */
+		*shift = 6;
+		*upper = (int64_t)(49.12 * ((int64_t)INT32_MAX + 1)) >> *shift;
+		*lower = -*upper;
+		*epsilon = (int64_t)(0.0015 * ((int64_t)INT32_MAX + 1)) >> *shift;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
 static const struct i2c_emul_api akm09918c_emul_api_i2c = {
 	.transfer = akm09918c_emul_transfer_i2c,
+};
+
+static const struct emul_sensor_backend_api akm09918c_emul_sensor_backend_api = {
+	.set_channel = akm09918c_emul_backend_set_channel,
+	.get_sample_range = akm09918c_emul_backend_get_sample_range,
 };
 
 #define AKM09918C_EMUL(n)                                                                          \
 	const struct akm09918c_emul_cfg akm09918c_emul_cfg_##n;                                    \
 	struct akm09918c_emul_data akm09918c_emul_data_##n;                                        \
 	EMUL_DT_INST_DEFINE(n, akm09918c_emul_init, &akm09918c_emul_data_##n,                      \
-			    &akm09918c_emul_cfg_##n, &akm09918c_emul_api_i2c, NULL)
+			    &akm09918c_emul_cfg_##n, &akm09918c_emul_api_i2c,                      \
+			    &akm09918c_emul_sensor_backend_api)
 
 DT_INST_FOREACH_STATUS_OKAY(AKM09918C_EMUL)

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/sensor.h>
+
+#include <stdint.h>
+
+/**
+ * @brief Collection of function pointers implementing a common backend API for sensor emulators
+ */
+struct emul_sensor_backend_api {
+	/** Sets a given fractional value for a given sensor channel. */
+	int (*set_channel)(const struct emul *emul, enum sensor_channel ch, q31_t value,
+			   uint8_t shift);
+	/** Retrieve a range of sensor values to use with test. */
+	int (*get_sample_range)(const struct emul *emul, enum sensor_channel ch, q31_t *lower,
+				q31_t *upper, q31_t *epsilon, int8_t *shift);
+};
+
+static inline bool emul_sensor_backend_is_supported(const struct emul *emul)
+{
+	return emul && emul->backend_api;
+}
+
+static inline int emul_sensor_backend_set_channel(const struct emul *emul, enum sensor_channel ch,
+						  q31_t value, uint8_t shift)
+{
+	if (!emul || !emul->backend_api) {
+		return -ENOTSUP;
+	}
+
+	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)emul->backend_api;
+
+	if (api->set_channel) {
+		return api->set_channel(emul, ch, value, shift);
+	}
+	return -ENOTSUP;
+}
+
+static inline int emul_sensor_backend_get_sample_range(const struct emul *emul,
+						       enum sensor_channel ch, q31_t *lower,
+						       q31_t *upper, q31_t *epsilon, int8_t *shift)
+{
+	if (!emul || !emul->backend_api) {
+		return -ENOTSUP;
+	}
+
+	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)emul->backend_api;
+
+	if (api->get_sample_range) {
+		return api->get_sample_range(emul, ch, lower, upper, epsilon, shift);
+	}
+	return -ENOTSUP;
+}

--- a/tests/drivers/build_all/sensor/CMakeLists.txt
+++ b/tests/drivers/build_all/sensor/CMakeLists.txt
@@ -4,5 +4,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(build_all)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+# Exclude main when running the generic test because ztest supplies its own
+target_sources_ifndef(CONFIG_RUN_GENERIC_SENSOR_TEST app PRIVATE src/main.c)
+target_sources_ifdef(CONFIG_RUN_GENERIC_SENSOR_TEST app PRIVATE src/generic_test.c)

--- a/tests/drivers/build_all/sensor/Kconfig
+++ b/tests/drivers/build_all/sensor/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+config RUN_GENERIC_SENSOR_TEST
+    bool "Compile and run the generic sensor tests"
+    depends on ZTEST && ZTEST_NEW_API
+    help Enables building and running the generic sensor test suite that will
+         iterate through the device tree and sun sample path tests on any
+         sensor that supports the backend sensor emulator API.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/build_all/sensor/src/generic_test.c
+++ b/tests/drivers/build_all/sensor/src/generic_test.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul_sensor.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/rtio.h>
+
+/*
+ * Set up an RTIO context that can be shared for all sensors
+ */
+
+static enum sensor_channel iodev_all_channels[SENSOR_CHAN_ALL];
+static struct sensor_read_config iodev_read_config = {
+	.sensor = NULL,
+	.channels = iodev_all_channels,
+	.count = 0,
+	.max = SENSOR_CHAN_ALL,
+};
+RTIO_IODEV_DEFINE(iodev_read, &__sensor_iodev_api, &iodev_read_config);
+
+/* Create the RTIO context to service the reading */
+RTIO_DEFINE_WITH_MEMPOOL(sensor_read_rtio_ctx, 1, 1, 1, 64, 4);
+
+/** Number of test points to use in the generic test. These are automatically generated. */
+#define NUM_EXPECTED_VALS (5)
+
+/**
+ * @brief Helper function the carries out the generic sensor test for a given sensor device.
+ *        Verifies that the device has a suitable emulator that implements the backend API and
+ *        skips the test gracefully if not.
+ */
+static void run_generic_test(const struct device *dev)
+{
+	zassert_not_null(dev, "Cannot get device pointer. Is this driver properly instantiated?");
+
+	const struct emul *emul = emul_get_binding(dev->name);
+
+	/* Skip this sensor if there is no emulator loaded. */
+	if (!emul) {
+		ztest_test_skip();
+	}
+
+	/* Also skip if this emulator does not implement the backend API. */
+	if (!emul_sensor_backend_is_supported(emul)) {
+		ztest_test_skip();
+	}
+
+	/*
+	 * Begin the actual test sequence
+	 */
+
+	static struct {
+		bool supported;
+		bool received;
+		q31_t expected_values[NUM_EXPECTED_VALS];
+		q31_t epsilon;
+		int8_t expected_value_shift;
+	} channel_table[SENSOR_CHAN_ALL];
+
+	/* Discover supported channels on this device and fill out our sensor read request */
+	for (enum sensor_channel ch = 0; ch < ARRAY_SIZE(channel_table); ch++) {
+		if (SENSOR_CHANNEL_3_AXIS(ch)) {
+			continue;
+		}
+
+		q31_t lower, upper;
+		int8_t shift;
+
+		if (emul_sensor_backend_get_sample_range(emul, ch, &lower, &upper,
+							 &channel_table[ch].epsilon, &shift) == 0) {
+			/* This channel is supported */
+			channel_table[ch].supported = true;
+
+			/* Add to the list of channels to read */
+			iodev_all_channels[iodev_read_config.count++] = ch;
+
+			/* Generate a set of NUM_EXPECTED_VALS test values */
+			channel_table[ch].expected_value_shift = shift;
+			for (size_t i = 0; i < NUM_EXPECTED_VALS; i++) {
+				channel_table[ch].expected_values[i] =
+					lower + (i * (upper - lower) / (NUM_EXPECTED_VALS - 1));
+			}
+		}
+	}
+	iodev_read_config.sensor = dev;
+
+	/* Do a read of all channels for quantity NUM_EXPECTED_VALS rounds. */
+
+	int rv;
+	uint8_t *buf = NULL;
+	uint32_t buf_len = 0;
+	const struct sensor_decoder_api *decoder;
+	sensor_frame_iterator_t fit;
+	sensor_channel_iterator_t cit;
+	enum sensor_channel channel;
+	q31_t q;
+	int8_t shift;
+	int missing_channel_count;
+
+	zassert_ok(sensor_get_decoder(dev, &decoder));
+
+	for (size_t round = 0; round < NUM_EXPECTED_VALS; round++) {
+		/* Reset received flag */
+		for (size_t i = 0; i < ARRAY_SIZE(channel_table); i++) {
+			channel_table[i].received = false;
+		}
+
+		/* Reset decoder state */
+		fit = (sensor_frame_iterator_t){0};
+		cit = (sensor_channel_iterator_t){0};
+
+		/* Set this round's expected values in emul for every supported channel */
+		for (size_t i = 0; i < iodev_read_config.count; i++) {
+			enum sensor_channel ch = iodev_all_channels[i];
+
+			zassert_ok(emul_sensor_backend_set_channel(
+					   emul, ch, channel_table[ch].expected_values[round],
+					   channel_table[ch].expected_value_shift),
+				   "Cannot set value %08x on channel %d (round %d)",
+				   channel_table[i].expected_values[round], ch, round);
+		}
+
+		/* Perform the actual sensor read */
+		rv = sensor_read(&iodev_read, &sensor_read_rtio_ctx, NULL);
+		zassert_ok(rv, "Got %d when reading sensor", rv);
+
+		/* Wait for a CQE */
+		struct rtio_cqe *cqe = rtio_cqe_consume_block(&sensor_read_rtio_ctx);
+
+		/* Cache the data from the CQE */
+		rtio_cqe_get_mempool_buffer(&sensor_read_rtio_ctx, cqe, &buf, &buf_len);
+
+		/* Release the CQE */
+		rtio_cqe_release(&sensor_read_rtio_ctx, cqe);
+
+		/* Decode the buffer and verify all channels */
+		while (decoder->decode(buf, &fit, &cit, &channel, &q, 1) > 0) {
+			zassert_true(channel_table[channel].supported);
+			zassert_false(channel_table[channel].received);
+			channel_table[channel].received = true;
+
+			zassert_ok(decoder->get_shift(buf, channel, &shift));
+
+			/* Align everything to be a 64-bit Q32.32 number for comparison */
+			int64_t expected_shifted = channel_table[channel].expected_values[round]
+						   << channel_table[channel].expected_value_shift;
+			int64_t actual_shifted = q << shift;
+			int64_t epsilon_shifted = channel_table[channel].epsilon
+						  << channel_table[channel].expected_value_shift;
+
+			zassert_within(expected_shifted, actual_shifted, epsilon_shifted,
+				       "Expected %lld, got %lld (shift=%d, ch=%d, round=%d)",
+				       expected_shifted, actual_shifted, shift, channel, round);
+		}
+
+		/* Release the memory */
+		rtio_release_buffer(&sensor_read_rtio_ctx, buf, buf_len);
+
+		/* Ensure all supported channels were received */
+		missing_channel_count = 0;
+		for (size_t i = 0; i < ARRAY_SIZE(channel_table); i++) {
+			if (channel_table[i].supported && !channel_table[i].received) {
+				missing_channel_count++;
+			}
+		}
+
+		zassert_equal(0, missing_channel_count);
+	}
+}
+
+#define DECLARE_ZTEST_PER_DEVICE(n)                                                                \
+	ZTEST(generic, test_##n)                                                                   \
+	{                                                                                          \
+		run_generic_test(DEVICE_DT_GET(n));                                                \
+	}
+
+/* Iterate through each of the emulated buses and create a test for each device. */
+DT_FOREACH_CHILD_STATUS_OKAY(DT_NODELABEL(test_i2c), DECLARE_ZTEST_PER_DEVICE)
+DT_FOREACH_CHILD_STATUS_OKAY(DT_NODELABEL(test_spi), DECLARE_ZTEST_PER_DEVICE)
+
+ZTEST_SUITE(generic, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -19,3 +19,12 @@ tests:
     extra_configs:
       - CONFIG_PM=y
       - CONFIG_PM_DEVICE=y
+  sensors.generic_test:
+    extra_configs:
+      - CONFIG_RUN_GENERIC_SENSOR_TEST=y
+      - CONFIG_ZTEST=y
+      - CONFIG_ZTEST_NEW_API=y
+      - CONFIG_EMUL=y
+      - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+      - CONFIG_SENSOR_ASYNC_API=y
+    build_only: false

--- a/tests/drivers/sensor/akm09918c/src/main.c
+++ b/tests/drivers/sensor/akm09918c/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/ztest.h>
 
+#include "akm09918c.h"
 #include "akm09918c_emul.h"
 #include "akm09918c_reg.h"
 
@@ -72,19 +73,19 @@ static void test_fetch_magnetic_field(const struct akm09918c_fixture *fixture,
 
 	/* Assert the data is within 0.000005 Gauss */
 	actual_ugauss = values[0].val1 * INT64_C(1000000) + values[0].val2;
-	expect_ugauss = magn_percent[0] * INT64_C(500);
+	expect_ugauss = magn_percent[0] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(X) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
 
 	actual_ugauss = values[1].val1 * INT64_C(1000000) + values[1].val2;
-	expect_ugauss = magn_percent[1] * INT64_C(500);
+	expect_ugauss = magn_percent[1] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(Y) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
 
 	actual_ugauss = values[2].val1 * INT64_C(1000000) + values[2].val2;
-	expect_ugauss = magn_percent[2] * INT64_C(500);
+	expect_ugauss = magn_percent[2] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(Z) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
@@ -95,7 +96,7 @@ ZTEST_F(akm09918c, test_fetch_magn)
 	/* Use (0.25, -0.33..., 0.91) as the factors */
 	const int16_t magn_percent[3] = {
 		INT16_C(32752) / INT16_C(4),
-		INT16_C(-32751) / INT16_C(3),
+		INT16_C(-32752) / INT16_C(3),
 		(int16_t)(INT16_C(32752) * INT32_C(91) / INT32_C(100)),
 	};
 


### PR DESCRIPTION
This PR introduces a backend API to be implemented by sensor emulators
that creates a standardized mechanism for setting expected sensor
readings in tests. This unlocks the ability to create a generic sensor
test that can automatically set expected values in supported sensor
emulators and verify them through the existing sensor API. An
implementation of this API is provided for the AKM09918C magnetometer.

A generic sensor test is also created to exercise this implementation.
Observe that this test knows nothing about the AKM09918C; info about
supported channels and sample ranges is discovered through the backend
API. The test iterates over all devices attached to the virtual I2C and
SPI buses in the test binary's device tree, which (theoretically) covers
all sensors. Sensors whose emulator does not exist yet or does not
support the backend API are skipped.